### PR TITLE
only re-sync the same lockfile when it _actually_ changed

### DIFF
--- a/lib/bundler/multilock/ext/shared_helpers.rb
+++ b/lib/bundler/multilock/ext/shared_helpers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Bundler
+  module Multilock
+    module Ext
+      module SharedHeleprs
+        module ClassMethods
+          ::Bundler::SharedHelpers.singleton_class.prepend(self)
+          ::Bundler::SharedHelpers.instance_variable_set(:@filesystem_accesses, nil)
+
+          def capture_filesystem_access
+            @filesystem_accesses = []
+            yield
+            @filesystem_accesses
+          ensure
+            @filesystem_accesses = nil
+          end
+
+          def filesystem_access(path, action = :write)
+            @filesystem_accesses << [path, action] if @filesystem_accesses
+
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
not just if it differed from the temporary constructed lockfile