### PR TITLE
don't log blank line before syncing anymore

### DIFF
--- a/lib/bundler/multilock.rb
+++ b/lib/bundler/multilock.rb
@@ -149,7 +149,6 @@ module Bundler
         require_relative "multilock/lockfile_generator"
 
         Bundler.ui.debug("Syncing to alternate lockfiles")
-        Bundler.ui.info ""
 
         attempts = 1
 


### PR DESCRIPTION
no longer useful now that `bundle install` output isn't noisy