### PR TITLE
Update references to "default" or "current" lockfile to be "active"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the default lockfile (Gemfile.lock), afterwhich all other lockfiles will
 be re-created based on this default lockfile. Additional lockfiles can be
 based on the same Gemfile, but vary at runtime. You can force a specific
 lockfile by setting the `BUNDLE_LOCKFILE` environment variable, or customize
-it any way you want by setting `current: true` on one of your lockfiles
+it any way you want by setting `active: true` on one of your lockfiles
 in your Gemfile.
 
 Alternately (or in addition!), you can define a lockfile to use a completely
@@ -85,7 +85,7 @@ with `BUNDLE_LOCKFILE`:
 BUNDLE_LOCKFILE=rails-7.0 bundle exec rspec
 ```
 
-You can also dynamically select it in your Gemfile, and pass `current: true`
+You can also dynamically select it in your Gemfile, and pass `active: true`
 to (exactly one!) `lockfile` method.
 
 In some cases, you may want to essentially disable bundler-multilock's

--- a/lib/bundler/multilock.rb
+++ b/lib/bundler/multilock.rb
@@ -65,7 +65,7 @@ module Bundler
         active = env_lockfile == lockfile if env_lockfile
 
         if active && (old_active = lockfile_definitions.find { |definition| definition[:active] })
-          raise ArgumentError, "Only one lockfile (#{old_active[:lockfile]}) can be flagged as the default"
+          raise ArgumentError, "Only one lockfile (#{old_active[:lockfile]}) can be flagged as active"
         end
 
         parent = expand_lockfile(parent)
@@ -314,7 +314,7 @@ module Bundler
         end
         return unless default_lockfile_definition && default_lockfile_definition[:active] == false
 
-        raise GemfileEvalError, "No lockfiles marked as default"
+        raise GemfileEvalError, "No lockfiles marked as active"
       end
 
       # @!visibility private

--- a/spec/bundler/multilock_spec.rb
+++ b/spec/bundler/multilock_spec.rb
@@ -103,30 +103,30 @@ describe "Bundler::Multilock" do
     end
   end
 
-  it "disallows multiple default lockfiles" do
+  it "disallows multiple active lockfiles" do
     with_gemfile(<<~RUBY) do
-      lockfile(default: true)
-      lockfile("full", default: true)
+      lockfile(active: true)
+      lockfile("full", active: true)
     RUBY
-      expect { invoke_bundler("install") }.to raise_error(/can be flagged as the default/)
+      expect { invoke_bundler("install") }.to raise_error(/can be flagged as active/)
     end
   end
 
   it "allows defaulting to an alternate lockfile" do
     with_gemfile(<<~RUBY) do
-      lockfile(default: false)
-      lockfile("full", default: true)
+      lockfile(active: false)
+      lockfile("full", active: true)
     RUBY
       invoke_bundler("install")
     end
   end
 
-  it "disallows no lockfile set as the default" do
+  it "disallows no lockfile set as active" do
     with_gemfile(<<~RUBY) do
-      lockfile(default: false)
+      lockfile(active: false)
       lockfile("full")
     RUBY
-      expect { invoke_bundler("install") }.to raise_error(/No lockfiles marked as default/)
+      expect { invoke_bundler("install") }.to raise_error(/No lockfiles marked as active/)
     end
   end
 
@@ -192,11 +192,11 @@ describe "Bundler::Multilock" do
     end
   end
 
-  it "bundle info, bundle list respect default" do
+  it "bundle info, bundle list respect active" do
     with_gemfile(<<~RUBY) do
       gem "rake", "13.0.6"
 
-      lockfile "variation1", default: true do
+      lockfile "variation1", active: true do
         gem "concurrent-ruby", "1.1.10"
       end
       lockfile "variation2" do
@@ -252,7 +252,7 @@ describe "Bundler::Multilock" do
 
   it "preserves the locked version of a gem in an alternate lockfile when updating a different gem in common" do
     with_gemfile(<<~RUBY) do
-      lockfile("full", default: true) do
+      lockfile("full", active: true) do
         gem "net-smtp", "0.3.2"
       end
 
@@ -265,7 +265,7 @@ describe "Bundler::Multilock" do
 
       # loosen the requirement on both gems
       write_gemfile(<<~RUBY)
-        lockfile("full", default: true) do
+        lockfile("full", active: true) do
           gem "net-smtp", "~> 0.3"
         end
 
@@ -465,14 +465,14 @@ describe "Bundler::Multilock" do
     with_gemfile(<<~RUBY) do
       gem "rake"
 
-      lockfile("full", default: true) do
+      lockfile("full", active: true) do
         gem "concurrent-ruby", "1.2.1"
       end
     RUBY
       invoke_bundler("install")
 
       write_gemfile(<<~RUBY)
-        lockfile("full", default: true) do
+        lockfile("full", active: true) do
           gem "concurrent-ruby", "~> 1.2.0"
         end
       RUBY
@@ -486,7 +486,7 @@ describe "Bundler::Multilock" do
     with_gemfile(<<~RUBY) do
       gem "concurrent-ruby", "1.2.1"
 
-      lockfile("full", default: true) do
+      lockfile("full", active: true) do
       end
     RUBY
       invoke_bundler("install")
@@ -494,7 +494,7 @@ describe "Bundler::Multilock" do
       write_gemfile(<<~RUBY)
         gem "concurrent-ruby", "~> 1.2.0"
 
-        lockfile("full", default: true) do
+        lockfile("full", active: true) do
         end
       RUBY
 
@@ -508,7 +508,7 @@ describe "Bundler::Multilock" do
     with_gemfile(<<~RUBY) do
       gem "concurrent-ruby", "1.2.1"
 
-      lockfile("full", default: true) do
+      lockfile("full", active: true) do
       end
     RUBY
       invoke_bundler("install")
@@ -516,7 +516,7 @@ describe "Bundler::Multilock" do
       write_gemfile(<<~RUBY)
         gem "concurrent-ruby", "~> 1.2.0"
 
-        lockfile("full", default: true) do
+        lockfile("full", active: true) do
         end
       RUBY
 
@@ -619,7 +619,7 @@ describe "Bundler::Multilock" do
     end
   end
 
-  it "allows explicitly specifying the default lockfile" do
+  it "allows explicitly specifying the active lockfile" do
     with_gemfile(<<~RUBY) do
       gem "rake"
 
@@ -686,7 +686,7 @@ describe "Bundler::Multilock" do
     with_gemfile(<<~RUBY) do
       gemspec
 
-      lockfile("rails-6.1", default: true) do
+      lockfile("rails-6.1", active: true) do
         gem "activesupport", "~> 6.1.0"
       end
     RUBY


### PR DESCRIPTION
The kwarg was changed from default to active quite a while ago