### PR TITLE
don't evaluate the default lockfile at all in certain cases

### DIFF
--- a/lib/bundler/multilock.rb
+++ b/lib/bundler/multilock.rb
@@ -60,7 +60,8 @@ module Bundler
           raise ArgumentError, "Lockfile #{lockfile} is already defined"
         end
 
-        env_lockfile = ENV["BUNDLE_LOCKFILE"]&.then { |l| expand_lockfile(l) }
+        env_lockfile = lockfile if active && ENV["BUNDLE_LOCKFILE"] == "active"
+        env_lockfile ||= ENV["BUNDLE_LOCKFILE"]&.then { |l| expand_lockfile(l) }
         active = env_lockfile == lockfile if env_lockfile
 
         if active && (old_active = lockfile_definitions.find { |definition| definition[:active] })

--- a/spec/bundler/multilock_spec.rb
+++ b/spec/bundler/multilock_spec.rb
@@ -736,6 +736,25 @@ describe "Bundler::Multilock" do
     end
   end
 
+  it "does not evaluate the default lockfile at all if an alternate is active, " \
+     "without specifying that lockfile explicitly" do
+    with_gemfile(<<~RUBY) do
+      gem "inst-jobs", "3.1.13"
+
+      lockfile active: ENV["ALTERNATE"] != "1" do
+        raise "evaluated!" if ENV["ALTERNATE"] == "1"
+      end
+
+      lockfile "alt", active: ENV["ALTERNATE"] == "1" do
+        gem "activerecord-pg-extensions"
+      end
+    RUBY
+      invoke_bundler("install")
+
+      invoke_bundler("install", env: { "ALTERNATE" => "1", "BUNDLE_LOCKFILE" => "active" })
+    end
+  end
+
   private
 
   def create_local_gem(name, content = "", subdirectory: true)


### PR DESCRIPTION
if an alternate lockfile is active, and while that's active for some reason the default lockfile is not evaluatable, just don't evaluate it (but without having to know outside of ruby which one will be active)