### PR TITLE
update CI to latest 2.4 release of bundler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: [2.7, "3.0", 3.1, 3.2]
-        bundler-version: [2.4.20, 2.5.2]
+        bundler-version: [2.4.19, 2.4.22, 2.5.2]
         exclude:
           - ruby-version: 2.7
             bundler-version: 2.5.2


### PR DESCRIPTION
also test oldest version we still support, to ensure we don't break it